### PR TITLE
Added encoding: utf-8 to makeebooks

### DIFF
--- a/makeebooks
+++ b/makeebooks
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 # This script convers markdown book to one of the serveral e-book
 # formats supported with calibre (http://calibre-ebook.com)
 #


### PR DESCRIPTION
Added encoding: utf-8 to makeebooks because of https://github.com/dyp2000/Russian-Armstrong-Erlang/issues/28
