### PR TITLE
Fix error in makeebooks script

### DIFF
--- a/makeebooks
+++ b/makeebooks
@@ -43,7 +43,7 @@ ARGV.each do |lang|
   dir = File.expand_path(File.join(File.dirname(__FILE__), lang))
   Dir[File.join(dir, '**', '*.md')].sort.each do |input|
     puts "processing #{input}"
-    content = File.read(input)
+    content = File.read(input, encoding: 'utf-8')
     content.gsub!(/Insert\s+(.*)(\.png)\s*\n?\s*#{figure_title}\s+(.*)/, '![\3](figures/\1-tn\2 "\3")')
     book_content << RDiscount.new(content).to_html
   end


### PR DESCRIPTION
I had an issue:
```bash
root@dbf3af6e5b5f:/tmp/app# ./makeebooks ru
using .mobi (you can change it via FORMAT environment variable. try 'mobi' or 'epub')
convert content for 'ru' language
processing /tmp/app/ru/00/Programming_Erlang_Title.md
processing /tmp/app/ru/01/Programming_Erlang_Ch01.md
./makeebooks:47:in `gsub!': invalid byte sequence in US-ASCII (ArgumentError)
	from ./makeebooks:47:in `block (2 levels) in <main>'
	from ./makeebooks:44:in `each'
	from ./makeebooks:44:in `block in <main>'
	from ./makeebooks:33:in `each'
	from ./makeebooks:33:in `<main>'
```

This PR fixes it.

Running ruby 3.0.2